### PR TITLE
Add error handling for empty project field

### DIFF
--- a/include/actions.h
+++ b/include/actions.h
@@ -13,8 +13,9 @@ void on_start_button_clicked(GtkButton *button, gpointer data);
 void on_terminate_button_clicked(GtkButton *button, gpointer data);
 // Callback function for the restart button click
 void on_restart_button_clicked(GtkButton *button, gpointer data);
-void on_dark_mode_button_clicked(GtkButton *button, gpointer user_data);
+void on_dark_mode_button_clicked(GtkButton *button, gpointer data);
 int read_options_from_application_support(Options *options);
 int save_options_to_application_support(const Options *options);
+void validate_entry_widget(GtkWidget *entry, gpointer data);
 
 #endif // ACTIONS_H

--- a/include/common.h
+++ b/include/common.h
@@ -37,6 +37,8 @@ typedef enum
   BUTTON_TYPE_DARK_MODE
 } ButtonType;
 
+void LOG(const char *restrict fmt, ...);
+
 #define DEFAULT_PORT 8080 // Define the default port
 
 #endif // COMMON_H

--- a/src/common.c
+++ b/src/common.c
@@ -1,0 +1,12 @@
+#include "common.h"
+
+void LOG(const char *restrict fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    time_t t = time(NULL);
+    struct tm tm = *localtime(&t);
+    printf("[%d:%d:%d] ", tm.tm_hour, tm.tm_min, tm.tm_sec);
+    vprintf(fmt, args);
+    va_end(args);
+}

--- a/src/connection.c
+++ b/src/connection.c
@@ -54,7 +54,15 @@ static void set_widgets_state(Widgets *widgets, WidgetsState state)
     }
     else
     {
-        gtk_widget_set_sensitive(GTK_WIDGET(widgets->start_button), TRUE);      // Enable the start button
+        // Only enable the start button if the entry is not empty
+        if (strcmp(gtk_editable_get_text(GTK_EDITABLE(widgets->file_entry)), "") == 0)
+        {
+            gtk_widget_set_sensitive(GTK_WIDGET(widgets->start_button), FALSE);
+        }
+        else
+        {
+            gtk_widget_set_sensitive(GTK_WIDGET(widgets->start_button), TRUE);
+        }
         gtk_widget_set_sensitive(GTK_WIDGET(widgets->terminate_button), FALSE); // Disable the terminate button
         gtk_widget_set_sensitive(GTK_WIDGET(widgets->restart_button), FALSE);   // Disable the restart button
         gtk_widget_set_sensitive(GTK_WIDGET(widgets->port_entry), TRUE);        // Enable the port entry
@@ -74,7 +82,7 @@ gboolean check_connection(gpointer data)
     {
         port = DEFAULT_PORT;
     }
-    char *label_text;
+
     if (is_port_open(port))
     {
         draw_green_status_light(widgets);

--- a/src/content.c
+++ b/src/content.c
@@ -144,6 +144,9 @@ void init_inputs_box(GtkWidget *inputs_box, Widgets *widgets)
     
     // Set hexpand to TRUE for the inputs_box
     gtk_widget_set_hexpand(inputs_box, TRUE);
+
+    // field validation for file_entry
+    g_signal_connect(widgets->file_entry, "changed", G_CALLBACK(validate_entry_widget), widgets);
 }
 
 void init_main_box(GtkWidget *main_box, GtkWidget *inputs_box, GtkWidget *button_box)


### PR DESCRIPTION
Disables start button when project directory field is empty or not pointing to a valid react native project root.

<img width="580" alt="image" src="https://github.com/user-attachments/assets/2bb3581c-0399-457c-bb8f-a7d51f850624">
<img width="580" alt="image" src="https://github.com/user-attachments/assets/e10a57a7-e860-4bd9-9e87-1f3e18958532">
